### PR TITLE
Protect routes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,15 @@ import { PageTemplate, Footer, Header } from "@/components/template";
 import HeroCarousel from "./_components/HeroCarousel";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { createClient } from "@/server/supabase/server";
+import { redirect } from "next/navigation";
 
-export default function HomePage() {
+export default async function HomePage() {
+  const supabase = await createClient();
+  const auth = await supabase.auth.getSession();
+
+  if (auth.data.session) return redirect("/dashboard");
+
   return (
     <PageTemplate>
       <Header />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,5 +6,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard"],
+  matcher: ["/dashboard/(.*)"],
 };


### PR DESCRIPTION
When user is logged in and lands in home redirect him to `/dashboard`.
And
If user is not logged in and tries to go to /dashboard/* redirect him to `/auth/sign/in`